### PR TITLE
Qa

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,16 +2,13 @@ class ApplicationController < ActionController::API
   include Responses
 
   before_action -> {
-    return true if authorize params
-
-    return_not_authorized("Given API key did not match a valid key")
+    # return true if authorize request is successful
+    (authorize request) || return_not_authorized("Given API key did not match a valid key")
   }
 
   private
-  def authorize (params)
-    params.permit(:api_key)
-
+  def authorize (request)
     # This key is temporarily stored in the ENV instead of the DB
-    (params.has_key? :api_key) && (params[:api_key] === ENV["API_KEY"])
+    request.headers["HTTP_API_KEY"] && (request.headers["HTTP_API_KEY"] === ENV["API_KEY"])
   end
 end

--- a/test/controllers/auth_controller_test.rb
+++ b/test/controllers/auth_controller_test.rb
@@ -4,25 +4,29 @@ class AuthControllerTest < ActionDispatch::IntegrationTest
   test "should return success when valid key is given" do
     ENV["API_KEY"] = "local"
 
-    post auth_login_url + "?api_key=" + ENV["API_KEY"], :params => { auth: { :username => "Test", :password => "Password"} }
+    post auth_login_url, :params => { auth: { userName: "test", password: "localTest" } }, headers: { HTTP_API_KEY: ENV["API_KEY"] }
 
     assert_response :success
   end
 
   test "should give unauthorized when no key is given" do
+    ENV["API_KEY"] = "local"
+
     post auth_login_url
     assert_response :unauthorized
   end
 
   test "should give unauthorized when non-matching key is given" do
-    post auth_login_url + "?api_key=" + 'foo'
+    ENV["API_KEY"] = "local"
+
+    post auth_login_url, headers: { HTTP_API_KEY: 'th' }
     assert_response :unauthorized
   end
 
   test "should post logout" do
     ENV["API_KEY"] = "local1"
 
-    post auth_logout_url + "?api_key=" + ENV["API_KEY"]
+    post auth_logout_url, headers: { HTTP_API_KEY: ENV["API_KEY"] }
 
     assert_response :success
   end
@@ -30,7 +34,7 @@ class AuthControllerTest < ActionDispatch::IntegrationTest
   test "should post oauth" do
     ENV["API_KEY"] = "local"
 
-    post auth_oauth_url + "?api_key=" + ENV["API_KEY"]
+    post auth_oauth_url, headers: { HTTP_API_KEY: ENV["API_KEY"] }
 
     assert_response :success
   end


### PR DESCRIPTION
Use headers instead of query strings for api key auth